### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,10 @@
 class ItemsController < ApplicationController
-    before_action :authenticate_user!, only: [:new]
-      def index
+  before_action :authenticate_user!, only: [:new]
+  def index
     @items = Item.all.order(id: 'DESC')
   end
 
   def new
-
     @item = Item.new
   end
 
@@ -16,6 +15,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,7 +35,6 @@ class ItemsController < ApplicationController
       :pref_id,
       :due_id
     ).merge(
-      star: '0',
       user_id: current_user.id
     )
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
             <div class='item-img-content'>
               <%= image_tag item.image.variant(resize:'500x500'), class: "item-img" if item.image.attached? %>
               <%# 商品が売れていればsold outの表示 %>
-              <% if item.state_id == 0 %>
+              <% if item.stock == false %>
               <div class='sold-out'>
                 <span>Sold Out!!</span>
               </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to(item_path(item.id), method: :get) do %>
             <div class='item-img-content'>
               <%= image_tag item.image.variant(resize:'500x500'), class: "item-img" if item.image.attached? %>
               <%# 商品が売れていればsold outの表示 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,7 @@
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,33 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
+      <%= image_tag @item.image, class: "item-box-img" if @item.image.attached? %>
+      <% if @item.stock == false %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+    <% if @item.user == current_user %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <% if user_signed_in? && (@item.user != current_user) && @item.stock == true %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+    <% end %>
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -42,27 +38,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.pref.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.due.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20200810045055_create_items.rb
+++ b/db/migrate/20200810045055_create_items.rb
@@ -3,15 +3,16 @@ class CreateItems < ActiveRecord::Migration[6.0]
     create_table :items do |t|
       # t.references :user, null: false, foreign_key: true
       t.integer :user_id,     null: false
-      t.string :title,        null: false
-      t.text :description,    null: false
+      t.string  :title,       null: false
+      t.text    :description, null: false
       t.integer :category_id, null: false
       t.integer :state_id,    null: false
       t.integer :charge_id,   null: false
       t.integer :pref_id,     null: false
       t.integer :due_id,      null: false
       t.integer :price,       null: false
-      t.integer :star,        null: false
+      t.integer :star,        null: false, default: 0
+      t.boolean :stock,       null: false, default: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,8 @@ ActiveRecord::Schema.define(version: 2020_08_17_091658) do
     t.integer "pref_id", null: false
     t.integer "due_id", null: false
     t.integer "price", null: false
-    t.integer "star", null: false
+    t.integer "star", default: 0, null: false
+    t.boolean "stock", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Item, type: :model do
     it '価格が300円より安いと出品できない' do
       @item.price = 299
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
-    end 
+      expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+    end
     it '価格が9,999,999円より高いと出品できない' do
       @item.price = 10_000_000
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+      expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
     end
     it 'category_idが空では出品できない' do
       @item.category_id = ''


### PR DESCRIPTION
# レビュー依頼 - 1
よろしくお願いします！
## what
- itemコントローラーにshowアクションを追加
- トップページに商品詳細ページへのリンクを設定
- 星の数と在庫の状態について変更
- 商品詳細ページのビューの編集
- rubocopの実行
- 商品詳細ページのビューの編集(2)

[出品したユーザーAが商品を表示する様子 (Gyazo)](https://gyazo.com/af287b6f66cc0dfc2c363be1fabd638f)
[出品していないユーザーBが商品を表示する様子 (Gyazo)](https://gyazo.com/d68feb71a697f7d35455856d56871361)

## why
- 商品詳細表示機能の実装